### PR TITLE
Add golangci-lint format to CI + linting fixes

### DIFF
--- a/.github/workflows/go-backend.yml
+++ b/.github/workflows/go-backend.yml
@@ -30,11 +30,11 @@ jobs:
       - name: Download dependencies
         run: go mod download
 
-      - name: Check gofmt
-        run: if [ "$(gofmt -s -l . | wc -l)" -gt 0 ]; then exit 1; fi
-
-      - name: Run go vet
-        run: go vet ./...
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@9fae48acfc02a90574d7c304a1758ef9895495fa # v7
+        with:
+          version: latest
+          working-directory: go-backend
 
       - name: Build backend server
         run: go build -o server ./cmd/server/main.go

--- a/go-backend/.golangci.yml
+++ b/go-backend/.golangci.yml
@@ -1,0 +1,43 @@
+version: "2"
+run:
+  issues-exit-code: 1
+linters:
+  enable:
+    - asciicheck
+    - errorlint
+    - gocritic
+    - gosec
+    - importas
+    - misspell
+    - prealloc
+    - revive
+    - staticcheck
+    - tparallel
+    - unconvert
+    - unparam
+    - whitespace
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - internal/third_party
+      - third_party$
+      - builtin$
+      - examples$
+issues:
+  uniq-by-line: false
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - internal/third_party
+      - third_party$
+      - builtin$
+      - examples$

--- a/go-backend/cmd/server/main.go
+++ b/go-backend/cmd/server/main.go
@@ -51,5 +51,7 @@ func main() {
 		port = "8080"
 	}
 
-	router.Run(":" + port)
+	if err := router.Run(":" + port); err != nil {
+		logger.Sugar.Fatal(err)
+	}
 }

--- a/go-backend/internal/handlers/local.go
+++ b/go-backend/internal/handlers/local.go
@@ -10,7 +10,7 @@ import (
 	"github.com/gittuf/visualizer/go-backend/internal/logger"
 	"github.com/gittuf/visualizer/go-backend/internal/models"
 	"github.com/gittuf/visualizer/go-backend/internal/services"
-	"github.com/gittuf/visualizer/go-backend/internal/utils"
+	"github.com/gittuf/visualizer/go-backend/internal/validation"
 
 	"github.com/gin-gonic/gin"
 )
@@ -27,7 +27,7 @@ func ListCommitsLocal(c *gin.Context) {
 	}
 
 	// Get absolute path
-	absPath, err := utils.GetAbsolutePath(req.Path)
+	absPath, err := validation.GetAbsolutePath(req.Path)
 	if err != nil {
 		c.JSON(http.StatusBadRequest, models.ErrorResponse{
 			Error:   "Invalid path",
@@ -38,7 +38,7 @@ func ListCommitsLocal(c *gin.Context) {
 	}
 
 	// Check if path exists
-	if !utils.PathExists(absPath) {
+	if !validation.PathExists(absPath) {
 		c.JSON(http.StatusBadRequest, models.ErrorResponse{
 			Error:   fmt.Sprintf("Path does not exist: %s", absPath),
 			Code:    http.StatusBadRequest,
@@ -48,7 +48,7 @@ func ListCommitsLocal(c *gin.Context) {
 	}
 
 	// Check if it's a valid git repository
-	if !utils.IsValidGitRepo(absPath) {
+	if !validation.IsValidGitRepo(absPath) {
 		c.JSON(http.StatusBadRequest, models.ErrorResponse{
 			Error:   fmt.Sprintf("Not a valid Git repository: %s", absPath),
 			Code:    http.StatusBadRequest,
@@ -84,7 +84,7 @@ func GetMetadataLocal(c *gin.Context) {
 	}
 
 	// Get absolute path
-	absPath, err := utils.GetAbsolutePath(req.Path)
+	absPath, err := validation.GetAbsolutePath(req.Path)
 	if err != nil {
 		c.JSON(http.StatusBadRequest, models.ErrorResponse{
 			Error:   "Invalid path",
@@ -95,7 +95,7 @@ func GetMetadataLocal(c *gin.Context) {
 	}
 
 	// Check if path exists
-	if !utils.PathExists(absPath) {
+	if !validation.PathExists(absPath) {
 		c.JSON(http.StatusBadRequest, models.ErrorResponse{
 			Error:   fmt.Sprintf("Path does not exist: %s", absPath),
 			Code:    http.StatusBadRequest,
@@ -105,7 +105,7 @@ func GetMetadataLocal(c *gin.Context) {
 	}
 
 	// Check if it's a valid git repository
-	if !utils.IsValidGitRepo(absPath) {
+	if !validation.IsValidGitRepo(absPath) {
 		c.JSON(http.StatusBadRequest, models.ErrorResponse{
 			Error:   fmt.Sprintf("Not a valid Git repository: %s", absPath),
 			Code:    http.StatusBadRequest,

--- a/go-backend/internal/services/git.go
+++ b/go-backend/internal/services/git.go
@@ -4,6 +4,7 @@
 package services
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -43,7 +44,7 @@ func CloneAndFetchRepo(url string) (string, func(), error) {
 		RefSpecs: []config.RefSpec{refSpec},
 		Progress: nil,
 	})
-	if err != nil && err != git.NoErrAlreadyUpToDate {
+	if err != nil && !errors.Is(err, git.NoErrAlreadyUpToDate) {
 		cleanup()
 		return "", nil, fmt.Errorf("failed to fetch refs/gittuf/policy: %w", err)
 	}

--- a/go-backend/internal/services/metadata.go
+++ b/go-backend/internal/services/metadata.go
@@ -6,6 +6,7 @@ package services
 import (
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -40,7 +41,7 @@ func DecodeMetadataBlob(repoPath, commitHash, metadataFilename string) (models.M
 	metadataPath := fmt.Sprintf("metadata/%s", metadataFilename)
 	file, err := tree.File(metadataPath)
 	if err != nil {
-		if err == object.ErrFileNotFound {
+		if errors.Is(err, object.ErrFileNotFound) {
 			return nil, fmt.Errorf("file metadata/%s not found in commit", metadataFilename)
 		}
 		return nil, fmt.Errorf("failed to get file: %w", err)

--- a/go-backend/internal/validation/validation.go
+++ b/go-backend/internal/validation/validation.go
@@ -1,7 +1,7 @@
 // Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package utils
+package validation
 
 import (
 	"os"


### PR DESCRIPTION
This PR includes the following in reference to https://github.com/gittuf/visualizer/issues/29

Added the golangci-lint-action to the go-backend CI pipleine. Disabled gofmt and go vet since golangci-lint configuration added in this PR from - https://github.com/gittuf/gittuf/blob/main/.golangci.yml includes the requisite checks.
Linting fixes for existing backend.